### PR TITLE
Fix for flash messages on edit profile being weird

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -27,7 +27,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if is_valid
       set_flash_message :notice, :updated
       sign_in @user, bypass: true
-      render "edit"
+      redirect_to edit_user_registration_path
     else
       render "edit"
     end


### PR DESCRIPTION
Was rendering the `edit` action after a successful user update rather than redirecting, so the flash message was persisting over two actions.

Fixes #3 